### PR TITLE
Introduction of UnityEditor variant of AI GameDebugger

### DIFF
--- a/.idea/.idea.Unity_AIBehavioursPackage/.idea/.gitignore
+++ b/.idea/.idea.Unity_AIBehavioursPackage/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/.idea.Unity_AIBehavioursPackage.iml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.Unity_AIBehavioursPackage/.idea/indexLayout.xml
+++ b/.idea/.idea.Unity_AIBehavioursPackage/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.Unity_AIBehavioursPackage/.idea/vcs.xml
+++ b/.idea/.idea.Unity_AIBehavioursPackage/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Assets/com.gamedeveducation.aibehaviours/Runtime/CommonCore/GameDebugger/Scripts/AIDebuggerCustomEditor.cs
+++ b/Assets/com.gamedeveducation.aibehaviours/Runtime/CommonCore/GameDebugger/Scripts/AIDebuggerCustomEditor.cs
@@ -1,0 +1,226 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.Events;
+
+
+// notes: derived from  https://docs.unity3d.com/Manual/UIE-HowTo-CreateEditorWindow.html
+
+namespace CommonCore
+{
+    public class AIDebuggerCustomEditor : EditorWindow, IGameDebugger
+    {
+        [SerializeField] string IndentString = "  ";
+        [SerializeField] UnityEvent<string> OnPopulateUI_SelectedObjectName = new();
+        [SerializeField] UnityEvent<string> OnPopulateUI_DebugText = new();
+        
+        [SerializeField] private int m_SelectedIndex = -1;
+        private VisualElement m_RightPane;
+
+        
+        List<IDebuggableObject> Sources = new();  // AI Agents available in scene
+        
+        // currently selected AI debugging data
+        int CurrentSourceIndex = -1;
+        IDebuggableObject CurrentSource => ((CurrentSourceIndex < 0) || (CurrentSourceIndex >= Sources.Count)) ? null : Sources[CurrentSourceIndex];
+
+        System.Text.StringBuilder DebugTextBuilder = new();
+        int IndentLevel = 0;
+        
+        
+        public static AIDebuggerCustomEditor Instance
+        {
+            get { return GetWindow< AIDebuggerCustomEditor >(); }
+        }
+        
+        
+        [MenuItem("Tools/AI Debugger")]
+        public static void ShowMyEditor()
+        {
+            // This method is called when the user selects the menu item in the Editor
+            EditorWindow wnd = GetWindow<AIDebuggerCustomEditor>();
+            wnd.titleContent = new GUIContent("AI Debugger");
+        }
+
+
+        void Update()
+        {
+            RefreshUI();
+        }
+        
+        
+        public void CreateGUI()
+        {
+            // Create a two-pane view with the left pane being fixed width
+            var splitView = new TwoPaneSplitView(0, 250, TwoPaneSplitViewOrientation.Horizontal);
+            
+            // Add the panel to the visual tree by adding it as a child to the root element
+            rootVisualElement.Add(splitView);
+            
+            // A TwoPaneSplitView always needs exactly two child elements
+            var leftPane = new ListView();
+            splitView.Add(leftPane);
+            m_RightPane = new ScrollView(ScrollViewMode.VerticalAndHorizontal);
+            splitView.Add(m_RightPane);
+            
+            // Initialize the list view with all the AI-Agent names
+            leftPane.makeItem = () => new Label();
+            leftPane.bindItem = (item, index) => { (item as Label).text = Sources[index].DebugDisplayName; };
+            leftPane.itemsSource = Sources;
+            
+            // React to the user's selection
+            //leftPane.selectionChanged += OnAISourceSelectionChange(leftPane.selectedIndex);
+            leftPane.selectedIndicesChanged += OnSelectedIndicesChange;
+            
+            // Restore the selection index from before the hot reload
+            leftPane.selectedIndex = m_SelectedIndex;
+            
+            // Store the selection index when the selection changes
+            leftPane.selectionChanged += (items) => { m_SelectedIndex = leftPane.selectedIndex; };
+            
+        }
+        
+        void RefreshUI()
+        {
+            // Clear all previous content from the pane
+            m_RightPane.Clear();
+            
+            // remove any nulls
+            for (int Index = Sources.Count - 1; Index >= 0; Index--)
+            {
+                if (Sources[Index] == null)
+                {
+                    Sources.RemoveAt(Index);
+
+                    if (Index == CurrentSourceIndex)
+                        CurrentSourceIndex = -1;
+                }
+            }
+
+            if ((CurrentSource == null) && (Sources.Count == 0))
+                CurrentSourceIndex = 0;
+
+            if (CurrentSource == null)
+            {
+                OnPopulateUI_SelectedObjectName.Invoke("No Sources");
+                OnPopulateUI_DebugText.Invoke("");
+                return;
+            }
+
+            OnPopulateUI_SelectedObjectName.Invoke(CurrentSource.DebugDisplayName);
+
+            // gather the debug data
+            var PrimarySource = CurrentSource;
+            DebugTextBuilder.Clear();
+            
+            foreach (var Source in Sources)
+            {
+                Source.GatherDebugData(this, Source == PrimarySource);
+            }
+            
+            var debugInformationLabel = new Label();
+            debugInformationLabel.text = DebugTextBuilder.ToString();
+            // Add the label control to the right-hand pane
+            m_RightPane.Add(debugInformationLabel);
+        }
+
+
+        
+        private void OnSelectedIndicesChange(IEnumerable<int> selectedItemIndex)
+        {
+            CurrentSourceIndex = selectedItemIndex.First();
+            // regenerate editor panel label with debug text contained within
+            RefreshUI();
+        }            
+            
+            
+        // private void OnAISourceSelectionChange(IEnumerable<object> selectedItems)
+        // {
+        //     selectedItems.ind
+        //     // regenerate editor panel label with debug text contained within
+        //     RefreshUI();
+        // }
+
+        public void AddEndLine()
+        {
+            DebugTextBuilder.AppendLine();
+        }
+        
+       
+        public void AddSectionHeader(string InText)
+        {
+            AddTextLine($"<color=orange>{InText}</color>");
+        }
+        
+        public void AddText(string InText, bool bUseCurrentIndent = true)
+        {
+            if (bUseCurrentIndent)
+            {
+                for (int Indent = 0; Indent < IndentLevel; Indent++)
+                    DebugTextBuilder.Append(IndentString);
+            }
+            
+            DebugTextBuilder.Append(InText);
+        }
+
+        public void AddTextLine(string InText, bool bUseCurrentIndent = true)
+        {
+            AddText(InText, bUseCurrentIndent);
+            AddEndLine();
+        }
+
+        public void PopIndent()
+        {
+            IndentLevel = Mathf.Max(0, IndentLevel - 1);
+        }
+
+        public void PushIndent()
+        {
+            ++IndentLevel;
+        }
+
+        public static void  AddSource(IDebuggableObject InObject)
+        {            
+            // todo:  code review needed.  look into how instancing of editor windows works
+            Instance.RegisterSource(InObject);
+        }
+        
+        public void RegisterSource(IDebuggableObject InObject)
+        {
+            if (Sources.Contains(InObject))
+                return;
+            
+            Sources.Add(InObject);
+            
+            if (CurrentSource == null)
+            {
+                CurrentSourceIndex = 0;
+                RefreshUI();
+            }
+        }
+
+        public static void RemoveSource(IDebuggableObject InObject)
+        {
+            // todo:  code review needed.  look into how instancing of editor windows works
+            Instance.UnregisterSource(InObject);
+        }
+
+        public void UnregisterSource(IDebuggableObject InObject)
+        {
+            if (CurrentSource == InObject)
+                CurrentSourceIndex = -1;
+            
+            Sources.Remove(InObject);
+            
+            if (CurrentSource == null)
+            {
+                if (Sources.Count > 0)
+                    CurrentSourceIndex = 0;
+            
+                RefreshUI();
+            }
+        }
+    }
+}

--- a/Assets/com.gamedeveducation.aibehaviours/Runtime/CommonCore/GameDebugger/Scripts/AIDebuggerCustomEditor.cs.meta
+++ b/Assets/com.gamedeveducation.aibehaviours/Runtime/CommonCore/GameDebugger/Scripts/AIDebuggerCustomEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e44d8b75e71a68f4b8956092c9a33c1b

--- a/Assets/com.gamedeveducation.aibehaviours/Runtime/HybridGOAP/Scripts/GOAPBrainBase.cs
+++ b/Assets/com.gamedeveducation.aibehaviours/Runtime/HybridGOAP/Scripts/GOAPBrainBase.cs
@@ -289,6 +289,7 @@ namespace HybridGOAP
             ConfigureBrain();
 
             GameDebugger.AddSource(this);
+            AIDebuggerCustomEditor.AddSource(this);
 
             ServiceLocator.RegisterService(CurrentBlackboard, gameObject);
 
@@ -301,6 +302,7 @@ namespace HybridGOAP
         void OnDestroy()
         {
             GameDebugger.RemoveSource(this);
+            AIDebuggerCustomEditor.RemoveSource(this);
         }
 
         void Update()


### PR DESCRIPTION
When editing, my preference is to use the **SceneView** more than **GameView** (e.g. for visibility of Navmesh, visibility of debug lines, quick camera navigation, etc).  

Currently, in order to view the AI GameDebugger information,  I need to keep both the GameView open simultaneously with my SceneView in order to view AI debug information - and that causes a screen real-estate issue.

I would prefer to have the same information available as a Unity CustomEditorWindow, meaning I can dock it wherever I'd like.

This PR is a first draft at duplicating your existing functionality (pretty closely) from the existing `GameDebugger`.     

I think there are almost certainly more polished ways to do what I've done,  but I thought it might help get a ball rolling.

Concerns:

- I have adopted the use of `IGameDebugger` as that seemed to be the intent behind alternative debuggers like this. However this requires us to implement `AddSource(...)` and `RemoveSource(...)`.  This:
    - means we have to register "sources" twice in `GOAPBrainBase`.
    - means we're now persisting two "sources of data" - one in the existing `GameDebugger` and duplicated again in this new proposed  `AIDebuggerCustomEditor`.
    
Suggestions:

- I feel that maybe that the persistence of "AI sources" would be better separated from the presentation of those items.    
    - Currently the `List<IDebuggableObject> Sources = new();`   (currently found in `GameDebugger`)  represents the "data".  This definitely feels like it should continue to be a singleton GO that can be referenced by other pieces of code ... and that this should be the only place where `AddSource(...)` etc is used.    
    - My suggestion is that the current "GameView Display" and my proposed "CustomerEditor" refer to the singleton for "sources",  but then separate their concerns for "rendering" that information separately.

Note:
I've just adopted the simple stringbuilder approach to building up the debug info.   It's fine, it looks the same ;-)

Issues:
This should probably be opened as a separate issue,  but I have propagated an existing bug whereby the displayname of an agent is appearing multiple times at the top of the debug information.   This varies depending on where the current selection is, within the collection of agents.      Only having a single agent will hide this problem.

![goap_debugger_glitch](https://github.com/GameDevEducation/Unity_AIBehavioursPackage/assets/16468333/73d0ab2e-700c-44bd-80d0-28f0a6d3ad7f)


